### PR TITLE
Editing icons, removing unused connections

### DIFF
--- a/A_Modelica/DroneLibrary/Examples/MavicAir/DroneTest_FMU_Synchronous.mo
+++ b/A_Modelica/DroneLibrary/Examples/MavicAir/DroneTest_FMU_Synchronous.mo
@@ -29,8 +29,6 @@ model DroneTest_FMU_Synchronous
         origin={20,-50})));
   Sensors.Accelerometer accelerometer
     annotation (Placement(transformation(extent={{10,-80},{30,-60}})));
-  Modelica.Blocks.Sources.Constant const1(k=0)
-    annotation (Placement(transformation(extent={{2,-42},{-10,-30}})));
   Mechanical.Propeller.Variants.MavicAir mavicAir_propeller1(PropellerGain=1) annotation (Placement(transformation(extent={{10,2},{30,10}})));
   Mechanical.Propeller.Variants.MavicAir mavicAir_propeller2 annotation (Placement(transformation(extent={{10,-8},{30,0}})));
   Mechanical.Propeller.Variants.MavicAir mavicAir_propeller3(PropellerGain=1) annotation (Placement(transformation(extent={{10,-18},{30,-10}})));
@@ -50,8 +48,6 @@ equation
                                           color={0,0,127}));
   connect(accelerometer.y, controlModule_Synchronous.Gyero) annotation (Line(
         points={{9,-70},{-20.9091,-70},{-20.9091,-12}}, color={0,0,127}));
-  connect(controlModule_Synchronous.Height, const1.y) annotation (Line(points={{
-          -16.6667,-12},{-16.6667,-36},{-10.6,-36}}, color={0,0,127}));
   connect(mavicAir_propeller1.position, controlModule_Synchronous.y)
     annotation (Line(points={{7.8,5.2},{-0.1,5.2},{-0.1,2},{-9.09091,2}}, color=
          {0,0,127}));

--- a/A_Modelica/DroneLibrary/Examples/MavicAir/controlModuleTest_fmu_main.mo
+++ b/A_Modelica/DroneLibrary/Examples/MavicAir/controlModuleTest_fmu_main.mo
@@ -3,31 +3,17 @@ model controlModuleTest_fmu_main
   extends Modelica.Icons.Example;
   Modelica.Blocks.Sources.Ramp ramp(duration=5, height=5)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
-        origin={-70,0})));
+        origin={-54,-12})));
   Modelica.Blocks.Sources.Constant const(k=0)
     annotation (Placement(transformation(extent={{-66,18},{-46,38}})));
   DroneTest_FMU_Synchronous droneTest_FMU_Synchronous
     annotation (Placement(transformation(extent={{-18,-16},{32,34}})));
-  Modelica.Blocks.Noise.UniformNoise uniformNoise(
-    samplePeriod=0.1,
-     y_min=-1,
-     y_max=1)
-    annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
-  Modelica.Blocks.Math.Add add
-    annotation (Placement(transformation(extent={{-48,-18},{-38,-8}})));
-   inner Modelica.Blocks.Noise.GlobalSeed globalSeed
-     annotation (Placement(transformation(extent={{-36,-36},{-26,-26}})));
 equation
   connect(const.y, droneTest_FMU_Synchronous.xcoord) annotation (Line(points={{
           -45,28},{-28,28},{-28,29},{-23,29}}, color={0,0,127}));
   connect(droneTest_FMU_Synchronous.ycoord, droneTest_FMU_Synchronous.xcoord)
     annotation (Line(points={{-23,9},{-36,9},{-36,28},{-28,28},{-28,29},{-23,29}},
         color={0,0,127}));
-  connect(ramp.y, add.u1) annotation (Line(points={{-59,0},{-54,0},{-54,-10},
-          {-49,-10}}, color={0,0,127}));
-  connect(add.u2, uniformNoise.y) annotation (Line(points={{-49,-16},{-49,
-          -30},{-59,-30}}, color={0,0,127}));
-  connect(droneTest_FMU_Synchronous.zcoord, add.u1) annotation (Line(points={{-23,
-          -11},{-56,0},{-54,0},{-54,-10},{-49,-10}}, color={0,0,127}));
+  connect(ramp.y, droneTest_FMU_Synchronous.zcoord) annotation (Line(points={{-43,-12},{-34,-12},{-34,-11},{-23,-11}}, color={0,0,127}));
   annotation (experiment(StopTime=10, Tolerance=0.01));
 end controlModuleTest_fmu_main;

--- a/A_Modelica/DroneLibrary/Examples/Phantom/DroneTest_FMU_Synchronous.mo
+++ b/A_Modelica/DroneLibrary/Examples/Phantom/DroneTest_FMU_Synchronous.mo
@@ -29,8 +29,6 @@ model DroneTest_FMU_Synchronous
         origin={20,-50})));
   Sensors.Accelerometer accelerometer
     annotation (Placement(transformation(extent={{10,-80},{30,-60}})));
-  Modelica.Blocks.Sources.Constant const1(k=0)
-    annotation (Placement(transformation(extent={{2,-42},{-10,-30}})));
   Mechanical.Propeller.Variants.Phantom phantom_propeller1(PropellerGain=1) annotation (Placement(transformation(extent={{10,2},{30,10}})));
   Mechanical.Propeller.Variants.Phantom phantom_propeller2 annotation (Placement(transformation(extent={{10,-8},{30,0}})));
   Mechanical.Propeller.Variants.Phantom phantom_propeller3(PropellerGain=1) annotation (Placement(transformation(extent={{10,-18},{30,-10}})));
@@ -49,8 +47,6 @@ equation
                                           color={0,0,127}));
   connect(accelerometer.y, controlModule_Synchronous.Gyero) annotation (Line(
         points={{9,-70},{-20.9091,-70},{-20.9091,-12}}, color={0,0,127}));
-  connect(controlModule_Synchronous.Height, const1.y) annotation (Line(points={{
-          -16.6667,-12},{-16.6667,-36},{-10.6,-36}}, color={0,0,127}));
   connect(phantom_propeller1.position, controlModule_Synchronous.y) annotation (
      Line(points={{7.8,5.2},{-0.1,5.2},{-0.1,2},{-9.09091,2}}, color={0,0,127}));
   connect(phantom_propeller2.position, controlModule_Synchronous.y2)

--- a/A_Modelica/DroneLibrary/Examples/Phantom/controlModuleTest.mo
+++ b/A_Modelica/DroneLibrary/Examples/Phantom/controlModuleTest.mo
@@ -33,8 +33,6 @@ model controlModuleTest
     annotation (Placement(transformation(extent={{-92,36},{-72,56}})));
   Blocks.Sources.circlePath circlePath
     annotation (Placement(transformation(extent={{-92,10},{-72,30}})));
-  Modelica.Blocks.Sources.Constant const1(k=0)
-    annotation (Placement(transformation(extent={{40,-98},{20,-78}})));
   Mechanical.Propeller.Variants.Phantom propeller_1_2(PropellerGain=1) annotation (Placement(transformation(extent={{8,20},{28,26}})));
   Mechanical.Propeller.Variants.Phantom propeller_1_3 annotation (Placement(transformation(extent={{8,10},{28,16}})));
   Mechanical.Propeller.Variants.Phantom propeller_1_4(PropellerGain=1) annotation (Placement(transformation(extent={{8,0},{28,6}})));
@@ -69,9 +67,6 @@ equation
     annotation (Line(points={{-71,24},{-58,24}}, color={0,0,127}));
   connect(circlePath.y1, realExtendMultiple.u1) annotation (Line(points={{
           -71,16},{-66,16},{-66,18},{-58,18}}, color={0,0,127}));
-   connect(controlModuleSpeed.Height, const1.y) annotation (Line(points={{
-        -16.6667,6},{-16.6667,-88},{19,-88}},
-                                       color={0,0,127}));
 connect(propeller_1_4.Airframe, droneChassis_1_1.frame_a3) annotation (Line(
     points={{28.2,1.8},{36,2},{36,10},{42,10}},
     color={95,95,95},

--- a/A_Modelica/DroneLibrary/Examples/Phantom/controlModuleTest_fmu_main.mo
+++ b/A_Modelica/DroneLibrary/Examples/Phantom/controlModuleTest_fmu_main.mo
@@ -3,31 +3,17 @@ model controlModuleTest_fmu_main
   extends Modelica.Icons.Example;
   Modelica.Blocks.Sources.Ramp ramp(duration=5, height=5)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
-        origin={-70,0})));
+        origin={-56,-8})));
   Modelica.Blocks.Sources.Constant const(k=0)
     annotation (Placement(transformation(extent={{-66,18},{-46,38}})));
   DroneTest_FMU_Synchronous droneTest_FMU_Synchronous
     annotation (Placement(transformation(extent={{-18,-16},{32,34}})));
-  Modelica.Blocks.Noise.UniformNoise uniformNoise(
-    samplePeriod=0.1,
-     y_min=-1,
-     y_max=1)
-    annotation (Placement(transformation(extent={{-80,-40},{-60,-20}})));
-  Modelica.Blocks.Math.Add add
-    annotation (Placement(transformation(extent={{-48,-18},{-38,-8}})));
-   inner Modelica.Blocks.Noise.GlobalSeed globalSeed
-     annotation (Placement(transformation(extent={{-36,-36},{-26,-26}})));
 equation
   connect(const.y, droneTest_FMU_Synchronous.xcoord) annotation (Line(points={{
           -45,28},{-28,28},{-28,29},{-23,29}}, color={0,0,127}));
   connect(droneTest_FMU_Synchronous.ycoord, droneTest_FMU_Synchronous.xcoord)
     annotation (Line(points={{-23,9},{-36,9},{-36,28},{-28,28},{-28,29},{-23,29}},
         color={0,0,127}));
-  connect(ramp.y, add.u1) annotation (Line(points={{-59,0},{-54,0},{-54,-10},
-          {-49,-10}}, color={0,0,127}));
-  connect(add.u2, uniformNoise.y) annotation (Line(points={{-49,-16},{-49,
-          -30},{-59,-30}}, color={0,0,127}));
-  connect(droneTest_FMU_Synchronous.zcoord, add.u1) annotation (Line(points={{-23,
-          -11},{-56,0},{-54,0},{-54,-10},{-49,-10}}, color={0,0,127}));
+  connect(droneTest_FMU_Synchronous.zcoord, ramp.y) annotation (Line(points={{-23,-11},{-42,-11},{-42,-8},{-45,-8}}, color={0,0,127}));
   annotation (experiment(StopTime=10, Tolerance=0.01));
 end controlModuleTest_fmu_main;

--- a/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_Dymola.mo
+++ b/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_Dymola.mo
@@ -1,5 +1,6 @@
 within DroneLibrary.Examples.Visualization;
 model ModuleTest_Dymola
+  extends Modelica.Icons.Example;
  replaceable DroneLibrary.Visualization.Inputs.Keyboard.KeyboardInputs_SimVis inputDevice constrainedby Interfaces.InputDevice_Dymola annotation (Placement(transformation(extent={{-28,-10},{-8,10}})));
   DroneWithIdealPower.Drone_IdealMachine_SynchronousPID
     controlModuleTest_fmu_inputs1
@@ -13,6 +14,5 @@ equation
  connect(inputDevice.Z, controlModuleTest_fmu_inputs1.zcoord)
    annotation (Line(points={{-7,-5},{-4,-5},{-4,-8},{10,-8}},
                    color={0,0,127}));
- annotation (Icon(graphics={
-   Bitmap(extent={{-98,-98},{98,98}}, fileName="modelica://DroneLibrary/Resources/Images/dronepic.jpg")}));
+  annotation (experiment(StopTime=360, __Dymola_Algorithm="Dassl"));
 end ModuleTest_Dymola;

--- a/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_Dymola.mo
+++ b/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_Dymola.mo
@@ -14,5 +14,5 @@ equation
  connect(inputDevice.Z, controlModuleTest_fmu_inputs1.zcoord)
    annotation (Line(points={{-7,-5},{-4,-5},{-4,-8},{10,-8}},
                    color={0,0,127}));
-  annotation (experiment(StopTime=360, __Dymola_Algorithm="Dassl"));
+  annotation (experiment(StopTime=360));
 end ModuleTest_Dymola;

--- a/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_NoInput.mo
+++ b/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_NoInput.mo
@@ -1,5 +1,6 @@
 within DroneLibrary.Examples.Visualization;
 model ModuleTest_NoInput
+  extends Modelica.Icons.Example;
   Modelica.Blocks.Sources.Ramp ramp(
     height=2,
     duration=4,
@@ -18,8 +19,7 @@ equation
           127}));
   connect(ramp.y, controlModuleTest_fmu_inputs1.ycoord) annotation (
       Line(points={{-45,28},{-36,28},{-36,9},{-23,9}}, color={0,0,127}));
-  annotation (Icon(graphics={
-                            Bitmap(extent={{-98,-98},{98,98}}, fileName="modelica://DroneLibrary/Resources/Images/dronepic.jpg")}),
+  annotation (
     experiment(
       StopTime=10,
       __Dymola_fixedstepsize=0.01,

--- a/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_SimVis.mo
+++ b/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_SimVis.mo
@@ -91,11 +91,14 @@ equation
         InlineOrder=2,
         InlineFixedStep=0.01)),
     Documentation(info="<html>
-<br>
+<p>
 This example requires a Professional Edition license for DLR's Visualization Library.
-<br>
+</p>
+<p>
 When using the Community Edition version of the library, one of the cameras in the model would need to be removed.
-<br>
+</p>
+<p>
 To obtain a license, see: <a href=\"https://visualization.ltx.de/\"> https://visualization.ltx.de/ </a>  
+</p>
 </html>"));
 end ModuleTest_SimVis;

--- a/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_SimVis.mo
+++ b/A_Modelica/DroneLibrary/Examples/Visualization/ModuleTest_SimVis.mo
@@ -1,5 +1,6 @@
 within DroneLibrary.Examples.Visualization;
 model ModuleTest_SimVis
+  extends Modelica.Icons.Example;
   DroneWithIdealPower.Drone_DCPM_Chassis controlModuleTest_fmu_inputs1
     annotation (Placement(transformation(extent={{14,-10},{34,10}})));
 
@@ -80,9 +81,7 @@ equation
      points={{18,-44},{30,-44},{30,-26},{18,-26}},
      color={95,95,95},
      thickness=0.5));
-  annotation (Icon( graphics={
-                            Bitmap(
-          extent={{-98,-98},{98,98}}, fileName="modelica://DroneLibrary/Resources/Images/dronepic.jpg")}),
+  annotation (
     experiment(
       StopTime=50,
       __Dymola_fixedstepsize=0.01,
@@ -90,5 +89,13 @@ equation
     __Dymola_experimentFlags(Advanced(
         InlineMethod=1,
         InlineOrder=2,
-        InlineFixedStep=0.01)));
+        InlineFixedStep=0.01)),
+    Documentation(info="<html>
+<br>
+This example requires a Professional Edition license for DLR's Visualization Library.
+<br>
+When using the Community Edition version of the library, one of the cameras in the model would need to be removed.
+<br>
+To obtain a license, see: <a href=\"https://visualization.ltx.de/\"> https://visualization.ltx.de/ </a>  
+</html>"));
 end ModuleTest_SimVis;


### PR DESCRIPTION
These changes are applied to Examples.Phantom and Examples.Visualization.
Visualization: should use the Example icon.
Phantom: removed unused connection in the MCU.