### PR TITLE
add missing each, remove experiment annotation from partial model

### DIFF
--- a/A_Modelica/DroneLibrary/Blocks/Control/continuousPID.mo
+++ b/A_Modelica/DroneLibrary/Blocks/Control/continuousPID.mo
@@ -22,7 +22,7 @@ model continuousPID
 Modelica.Blocks.Continuous.TransferFunction transferFunction1(
     b={(kp + ki*2 + kd),(-kp + ki*2 - 2*kd),kd},
     a={1,-1,0},
-    x(fixed=true))
+    x(each fixed=true))
   annotation (Placement(transformation(extent={{4,-10},{24,10}})));
 equation
 

--- a/A_Modelica/DroneLibrary/Blocks/Control/discreteTF.mo
+++ b/A_Modelica/DroneLibrary/Blocks/Control/discreteTF.mo
@@ -22,7 +22,7 @@ Modelica.Clocked.RealSignals.Periodic.TransferFunction transferFunction1(
   b={(kp + ki*samplePeriod/2 + kd/samplePeriod),(-kp + ki*samplePeriod/2 - 2*
       kd/samplePeriod),kd/samplePeriod},
   a={1,-1,0},
-  x(fixed=true))
+  x(each fixed=true))
   annotation (Placement(transformation(extent={{-14,-10},{6,10}})));
 Modelica.Clocked.ClockSignals.Clocks.PeriodicRealClock periodicClock(period=
       period)

--- a/A_Modelica/DroneLibrary/Examples/Drone_Template.mo
+++ b/A_Modelica/DroneLibrary/Examples/Drone_Template.mo
@@ -26,6 +26,5 @@ equation
           lineColor={215,215,215},
           lineThickness=1), Bitmap(
           extent={{-98,-98},{98,98}}, fileName="modelica://DroneLibrary/Resources/Images/Otus.jpg")}),
-    __Dymola_Commands(file="modelica://DroneLibrary/Resources/Scripts/drone_animation_setup.mos" "drone_animation_setup"),
-     experiment(StopTime=10));
+    __Dymola_Commands(file="modelica://DroneLibrary/Resources/Scripts/drone_animation_setup.mos" "drone_animation_setup"));
 end Drone_Template;


### PR DESCRIPTION
Fixed some minor issues that would help with the OpenModelica testing:
https://libraries.openmodelica.org/branches/master/DroneLibrary/DroneLibrary.html
- add missing each
- partial models should not be able to simulate without extending so it makes no sense to have the `experiment` annotation.

