### PR TITLE
change `useQuaternions` flag to `true` in Multibody Parts for OpenModelica compatibility

### DIFF
--- a/A_Modelica/DroneLibrary/Mechanical/Blades/Templates/Blades.mo
+++ b/A_Modelica/DroneLibrary/Mechanical/Blades/Templates/Blades.mo
@@ -6,7 +6,7 @@ partial model Blades
     m=m,
     r=r,
     I_33=0.001,
-    useQuaternions=false)
+    useQuaternions=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,
         origin={66,-10})));
@@ -17,7 +17,7 @@ partial model Blades
     r=r,
     I_33=0.001,
     shapeType="cylinder",
-    useQuaternions=false)
+    useQuaternions=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=90,
         origin={66,10})));

--- a/A_Modelica/DroneLibrary/Mechanical/Blades/Variants/Blades.mo
+++ b/A_Modelica/DroneLibrary/Mechanical/Blades/Variants/Blades.mo
@@ -6,7 +6,7 @@ model Blades
     m=0.010,
     r={-0.154,0,0},
     I_33=0.001,
-    useQuaternions=false)
+    useQuaternions=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,
         origin={66,-10})));
@@ -17,7 +17,7 @@ model Blades
     r={0.154,0,0},
     I_33=0.001,
     shapeType="cylinder",
-    useQuaternions=false)
+    useQuaternions=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=90,
         origin={66,10})));

--- a/A_Modelica/DroneLibrary/Mechanical/Blades/Variants/Blades_Visualize.mo
+++ b/A_Modelica/DroneLibrary/Mechanical/Blades/Variants/Blades_Visualize.mo
@@ -5,7 +5,7 @@ model Blades_Visualize
     m=0.010,
     r={-0.154,0,0},
     I_33=0.001,
-    useQuaternions=false)
+    useQuaternions=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,
         origin={66,-10})));
@@ -15,7 +15,7 @@ model Blades_Visualize
     r={0.154,0,0},
     I_33=0.001,
     shapeType="cylinder",
-    useQuaternions=false)
+    useQuaternions=true)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=90,
         origin={66,10})));

--- a/A_Modelica/DroneLibrary/Mechanical/Chassis/Templates/droneChassis.mo
+++ b/A_Modelica/DroneLibrary/Mechanical/Chassis/Templates/droneChassis.mo
@@ -6,7 +6,7 @@ model droneChassis
     r={0,0.25,0},
     r_CM={0,0.175,0},
     m=m,
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{-22,34},{-2,54}})));
   Modelica.Mechanics.MultiBody.Parts.BodyShape bodyShape1(
     animation=false,
@@ -14,7 +14,7 @@ model droneChassis
     r={0.25,0,0},
     r_CM={0.175,0,0},
     m=m,
-  useQuaternions=false)
+  useQuaternions=true)
                       annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         origin={-12,12})));
@@ -24,7 +24,7 @@ model droneChassis
     m=m,
     r={0,-0.25,0},
     r_CM={0,-0.175,0},
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{-22,-26},{-2,-6}})));
   Modelica.Mechanics.MultiBody.Parts.BodyShape bodyShape3(
     animation=false,
@@ -32,7 +32,7 @@ model droneChassis
     m=m,
     r={-0.25,0,0},
     r_CM={-0.175,0,0},
-  useQuaternions=false)
+  useQuaternions=true)
                        annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         origin={-12,-50})));
@@ -43,7 +43,7 @@ model droneChassis
     diameter=0.01,
     r={0,0,-length},
     length=length,
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{32,-10},{52,10}})));
   Modelica.Mechanics.MultiBody.Parts.PointMass pointMass(
     animation=false,

--- a/A_Modelica/DroneLibrary/Mechanical/Chassis/Variants/droneChassis_NoAnimation.mo
+++ b/A_Modelica/DroneLibrary/Mechanical/Chassis/Variants/droneChassis_NoAnimation.mo
@@ -6,14 +6,14 @@ model droneChassis_NoAnimation
     r={0,0.25,0},
     r_CM={0,0.175,0},
     m=m,
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{-22,36},{-2,56}})));
   Modelica.Mechanics.MultiBody.Parts.BodyShape bodyShape1(
     animation=true,
     r={0.25,0,0},
     r_CM={0.175,0,0},
     m=m,
-  useQuaternions=false)
+  useQuaternions=true)
                       annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         origin={-12,14})));
@@ -22,14 +22,14 @@ model droneChassis_NoAnimation
     m=m,
     r={0,-0.25,0},
     r_CM={0,-0.175,0},
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{-22,-24},{-2,-4}})));
   Modelica.Mechanics.MultiBody.Parts.BodyShape bodyShape3(
     animation=true,
     m=m,
     r={-0.25,0,0},
     r_CM={-0.175,0,0},
-  useQuaternions=false)
+  useQuaternions=true)
                        annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         origin={-12,-48})));
@@ -40,7 +40,7 @@ model droneChassis_NoAnimation
     diameter=0.01,
     r={0,0,-length},
     length=length,
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{32,-10},{52,10}})));
   Modelica.Mechanics.MultiBody.Parts.PointMass pointMass(
     animation=true,

--- a/A_Modelica/DroneLibrary/Mechanical/Chassis/Variants/droneChassis_Visualize.mo
+++ b/A_Modelica/DroneLibrary/Mechanical/Chassis/Variants/droneChassis_Visualize.mo
@@ -8,7 +8,7 @@ model droneChassis_Visualize
     diameter=0.01,
     r={0,0,-length},
     length=length,
-  useQuaternions=false)
+  useQuaternions=true)
     annotation (Placement(transformation(extent={{32,-10},{52,10}})));
   Modelica.Mechanics.MultiBody.Parts.PointMass pointMass(
     animation=false,


### PR DESCRIPTION
Hello, 

In order to run the examples in OpenModelica I needed to change the `useQuaternion` flag in the Multidboy parts of the drone to `true`. Without this change, I was not able to run the simulations due to an orientation error.

I am using OpenModelica 1.26 in Ubuntu 24.
 
Miguel